### PR TITLE
Experiment polling with jest in typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea/
 node_modules/
+*.vue.d.ts

--- a/Dropdown.test.ts
+++ b/Dropdown.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import Dropdown from './Dropdown.vue';
+import { pollUntil } from "./poll";
 
 describe('Dropdown', () => {
   it('click opens the dropdown', async () => {
@@ -9,6 +10,8 @@ describe('Dropdown', () => {
     expect(button.attributes('aria-expanded')).toBe('false'); // expect closed initially
 
     await button.trigger('keydown.space');
-    expect(button.attributes('aria-expanded')).toBe('true'); // expect open after click
+
+    // expect eventual open after click
+    await pollUntil(() => button.attributes('aria-expanded') === 'true')
   });
 });

--- a/Dropdown.vue
+++ b/Dropdown.vue
@@ -29,13 +29,13 @@ export default defineComponent({
   methods: {
     async toggleMenu() {
       if (this.isOpen) {
-        await this.close();
+        this.close();
       } else {
         await this.open();
       }
     },
     async open() {
-      await new Promise<void>((resolve) => setTimeout(() => resolve(), 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       this.isOpen = true;
     },
     close() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,6 +1552,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "dev": true,
+      "requires": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "test": "jest"
+    "declare:vue": "vue-tsc --declaration --noEmit false --emitDeclarationOnly --project tsconfig.vue-tsc.json",
+    "test": " npm run declare:vue && jest"
   },
   "dependencies": {
     "vue": "^3.2.31"
@@ -13,6 +14,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
+    "@types/jest": "^27.4.1",
     "@vue/test-utils": "^2.0.0-rc.18",
     "@vue/vue3-jest": "^27.0.0-alpha.4",
     "jest": "^27.5.1",

--- a/poll.ts
+++ b/poll.ts
@@ -1,0 +1,10 @@
+export async function pollUntil(check:() => boolean, pollMs=10, timeoutMs=1000){
+    const startMs = new Date().getTime();
+    while(new Date().getTime() - startMs < timeoutMs){
+        if(check()){
+            return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+    throw new Error(`Timeout exceeded: ${check.toString()}`)
+}

--- a/tsconfig.vue-tsc.json
+++ b/tsconfig.vue-tsc.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.vue"]
+}


### PR DESCRIPTION
This migrates the example to Jest in typescript and adds a minimal poll implementation which might be useful for tests that complete 'eventually'.